### PR TITLE
Fixed logger bug #29 (forgot to reassign to `unparsed_code`)

### DIFF
--- a/src/compiler/Compiler.py
+++ b/src/compiler/Compiler.py
@@ -138,7 +138,7 @@ class Compiler:
 		# For each special character
 		for special_char, escaped_char in PY_SPECIAL_CHARS.items():
 			# Replace with the escaped version
-			unparsed_code.replace(special_char, escaped_char)
+			unparsed_code = unparsed_code.replace(special_char, escaped_char)
 
 		# Return the escaped string
 		return unparsed_code

--- a/src/compiler/Constants.py
+++ b/src/compiler/Constants.py
@@ -1,8 +1,8 @@
 """
 Constants and other 'singleton' objects and maps/dicts.
 """
-from _ast import Constant, BinOp, operator, Add, Sub, Mult, AnnAssign, AST, Expr, Name, Call, FunctionDef, arg, Return, \
-	Assign
+from _ast import Constant, BinOp, operator, Add, Sub, Mult, AnnAssign, AST, Expr, Name, Call, FunctionDef, arg, \
+	Return, Assign
 from typing import Dict, Type
 
 from src.pyexpressions.PyAnnAssign import PyAnnAssign
@@ -37,9 +37,6 @@ AST_OP_TO_STR: Dict[Type[operator], str] = {
 }
 
 PY_SPECIAL_CHARS: Dict[str, str] = {
-	"'": "\\'",
-	'"': '\\"',
-	"\\": "\\\\",
 	"\r": "\\r",
 	"\n": "\\n",
 	"\t": "\\t",


### PR DESCRIPTION
Closes #29 